### PR TITLE
rename project-radius to radius-project

### DIFF
--- a/.github/ISSUE_TEMPLATE/community-call-agenda.md
+++ b/.github/ISSUE_TEMPLATE/community-call-agenda.md
@@ -8,7 +8,7 @@ assignees: ''
 
 ## 📞 Radius Community Meeting
 
-Every month we host a [community meeting](https://github.com/project-radius/community/#community-meetings) to highlight community created content, showcase new features, review upcoming milestones, and engage in Q&A with the Radius community - all are welcome and encouraged to participate.
+Every month we host a [community meeting](https://github.com/radius-project/community/#community-meetings) to highlight community created content, showcase new features, review upcoming milestones, and engage in Q&A with the Radius community - all are welcome and encouraged to participate.
 
 The purpose of this thread is to form a discussion amongst the Radius community on potential topics to highlight during the meeting. If you have a topic you wish to present or learn more about, please add a comment and be sure to include your name and a short description of the topic.
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Every month we host a community call to showcase new features, review upcoming m
 
 Issues in the community repo are used to suggest topics for an upcoming Radius community call. Upcoming community meetings are pinned as issues in this repository. If you would like to present or discuss something during an upcoming community meeting, please propose the topic and add a comment to the issue corresponding to the desired meeting occurrence. Alternatively, you may use Discord to propose future agenda topics. The meeting agenda for each call is finalized by the community call host.
 
-<!-- Community members (members of the Radius GitHub org) can nominate themselves via an issue in the `project-radius/community` repository to be a community call host. Members become approved community call hosts when two or more existing community hosts approve their request, similar to how members and approvers get accepted today. -->
+<!-- Community members (members of the Radius GitHub org) can nominate themselves via an issue in the `radius-project/community` repository to be a community call host. Members become approved community call hosts when two or more existing community hosts approve their request, similar to how members and approvers get accepted today. -->
 
 <!-- You can always catch up offline by watching the recordings below. -->
 
@@ -89,14 +89,14 @@ One of the easiest ways to contribute is to participate in discussions at commun
 
 If you're looking for something to work on, read the [contribution guidelines](https://docs.radapp.dev/contributing/) and then you start by looking for GitHub issues, marked with `good first issue` or the `help wanted` labels:
 
-- [Radius repo](https://github.com/project-radius/radius/labels/good%20first%20issue)
-- [Documentation repo](https://github.com/project-radius/docs/labels/good%20first%20issue)
-- [Recipes repo](https://github.com/project-radius/recipes/labels/good%20first%20issue)
-- [Samples repo](https://github.com/project-radius/samples/labels/good%20first%20issue)
+- [Radius repo](https://github.com/radius-project/radius/labels/good%20first%20issue)
+- [Documentation repo](https://github.com/radius-project/docs/labels/good%20first%20issue)
+- [Recipes repo](https://github.com/radius-project/recipes/labels/good%20first%20issue)
+- [Samples repo](https://github.com/radius-project/samples/labels/good%20first%20issue)
 
 And, we can always use more testing, have more and improved docs, or just write a blog post on what you have discovered whilst using Radius.
 
-If you're a developer, read the [development guide](https://github.com/project-radius/radius/tree/main/docs) for help on how to get started.
+If you're a developer, read the [development guide](https://github.com/radius-project/radius/tree/main/docs) for help on how to get started.
 
 ## Code of Conduct
 

--- a/community-membership.md
+++ b/community-membership.md
@@ -46,12 +46,12 @@ Defined by: Member of the Radius GitHub organization
   - Sponsors must have close interactions with the prospective member - e.g. code/design/proposal review, coordinating on issues, etc
   - Sponsors must be approvers or maintainers in at least one CODEOWNERS file in any repo in the Radius org
 - [Open an
-  issue](https://github.com/project-radius/community/tree/main/.github/ISSUE_TEMPLATE?template=membership.md&title=REQUEST%3A%20New%20membership%20for%20%3Cyour-GH-handle%3E)
+  issue](https://github.com/radius-project/community/tree/main/.github/ISSUE_TEMPLATE?template=membership.md&title=REQUEST%3A%20New%20membership%20for%20%3Cyour-GH-handle%3E)
   against the
-  [Radius/community](https://github.com/project-radius/community) repo
+  [Radius/community](https://github.com/radius-project/community) repo
   - Ensure your sponsors are `@mentioned` on the issue
   - Complete every item on the checklist ([preview the current version of the
-    template- must update link](https://github.com/project-radius/community/tree/main/.github/ISSUE_TEMPLATE/membership.md))
+    template- must update link](https://github.com/radius-project/community/tree/main/.github/ISSUE_TEMPLATE/membership.md))
   - Make sure that the list of contributions included is representative of your work on the project
 - Have your sponsoring reviewers reply confirmation of sponsorship: `+1`
 - Once your sponsors have responded, your request will be reviewed by the Steering & Technical Committee (STC). Any member of the Steering & Technical Committee can review the requirements and add Members to the GitHub org


### PR DESCRIPTION
As part of OSS effort, we should rename all occurrences of project-radius to radius-project in our repos.