### PR TITLE
add Feb 2026 community call

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Use the upcoming calendar events below to add the community call events to your 
 
 | Date & time | Agenda |
 |-------------|--------|
-| Tuesday March 17 <sup>th</sup>, 2026 9:00am Pacific Time (PST)<br />[_See it in your local time and add to your calendar_](https://www.timeanddate.com/worldclock/fixedtime.html?iso=20260317T09&p1=234&msg=Radius+Community+Call) | radius-project/community#105
+| Wednesday March 18 <sup>th</sup>, 2026 9:00am Pacific Time (PST)<br />[_See it in your local time and add to your calendar_](https://www.timeanddate.com/worldclock/fixedtime.html?iso=20260318T09&p1=234&msg=Radius+Community+Call) | radius-project/community#105
 
 ### Previous calls
 


### PR DESCRIPTION
This pull request updates the community call schedule in the `README.md` file to reflect upcoming and past events. The main change is updating the next scheduled call and adding a new entry for a previous call.

Community Call Schedule Updates:

* Updated the upcoming community call date from February 10, 2026 to March 10, 2026, including the corresponding agenda reference and calendar link.
* Added the February 10, 2026 community call to the "Previous calls" section with a YouTube link and agenda reference.