### PR TITLE
Add Dependabot cooldown to all updates entries

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: ci
       include: scope


### PR DESCRIPTION
## Summary

Adds a `cooldown` block with `default-days: 7` to the active `updates:` entry in `.github/dependabot.yml`.

The cooldown block delays Dependabot update PRs until 7 days after a dependency release, reducing PR churn from brand-new releases that may still be unstable or get quickly superseded.

## Details

- Scoped to this repo (`radius-project/community`).
- Part of an org-wide rollout following [radius-project/radius #12141](https://github.com/radius-project/radius/pull/12141) ("Add Dependabot cooldown to all updates entries").
- `cooldown:` is aligned with the sibling `schedule:`/`groups:` keys and inserted immediately after the `schedule:` block.
- Only the single active `github-actions` entry exists; no commented-out entries were touched and no entry already had a cooldown.
- Uses `default-days: 7` only — no semver overrides.

## Type of change

Maintenance / no functional change. This only affects Dependabot's update scheduling behavior; no application code or runtime behavior is modified.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>